### PR TITLE
feat: resolve uv_tid alias for the certificate template id

### DIFF
--- a/src/main/java/io/uverify/backend/service/IdentityIndexerService.java
+++ b/src/main/java/io/uverify/backend/service/IdentityIndexerService.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.uverify.backend.entity.UVerifyCertificateEntity;
 import io.uverify.backend.entity.UVerifyCredentialEntity;
 import io.uverify.backend.repository.CredentialRepository;
+import io.uverify.backend.util.TemplateIdResolver;
 import jakarta.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -95,7 +96,7 @@ public class IdentityIndexerService {
         Map<String, Object> fields = objectMapper.readValue(extra, new TypeReference<>() {
         });
 
-        if (!IDENTITY_AUTH_TEMPLATE_ID.equals(fields.get("uverify_template_id"))) {
+        if (!IDENTITY_AUTH_TEMPLATE_ID.equals(TemplateIdResolver.resolveTemplateId(fields))) {
             return;
         }
 

--- a/src/main/java/io/uverify/backend/service/StatisticsService.java
+++ b/src/main/java/io/uverify/backend/service/StatisticsService.java
@@ -19,7 +19,6 @@
 package io.uverify.backend.service;
 
 import com.bloxbean.cardano.yaci.store.events.internal.CommitEvent;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.uverify.backend.dto.UsageStatistics;
 import io.uverify.backend.entity.StatisticEntity;
@@ -28,6 +27,7 @@ import io.uverify.backend.extension.ExtensionManager;
 import io.uverify.backend.repository.CertificateRepository;
 import io.uverify.backend.repository.StatisticRepository;
 import io.uverify.backend.repository.TransactionRepository;
+import io.uverify.backend.util.TemplateIdResolver;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -120,11 +120,11 @@ public class StatisticsService {
             return UseCaseCategory.NOTARY;
         }
         try {
-            JsonNode templateId = mapper.readTree(extra).get("uverify_template_id");
-            if (templateId == null || templateId.isNull()) {
+            String templateId = TemplateIdResolver.resolveTemplateId(mapper.readTree(extra));
+            if (templateId == null) {
                 return UseCaseCategory.NOTARY;
             }
-            return switch (templateId.asText()) {
+            return switch (templateId) {
                 case "tadamon" -> UseCaseCategory.IDENTITY;
                 case "socialHub", "linktree", "productVerification" -> UseCaseCategory.CONNECTED_GOODS;
                 case "diploma" -> UseCaseCategory.STUDENT_CERTIFICATION;

--- a/src/main/java/io/uverify/backend/util/TemplateIdResolver.java
+++ b/src/main/java/io/uverify/backend/util/TemplateIdResolver.java
@@ -1,0 +1,63 @@
+/*
+ * UVerify Backend
+ * Copyright (C) 2025 Fabian Bormann
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package io.uverify.backend.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Map;
+
+
+public final class TemplateIdResolver {
+
+    public static final String TEMPLATE_ID_KEY = "uv_tid";
+    public static final String LEGACY_TEMPLATE_ID_KEY = "uverify_template_id";
+
+    private TemplateIdResolver() {
+    }
+
+    public static String resolveTemplateId(JsonNode extraRoot) {
+        if (extraRoot == null) {
+            return null;
+        }
+        JsonNode shortKey = extraRoot.get(TEMPLATE_ID_KEY);
+        if (shortKey != null && shortKey.isTextual()) {
+            return shortKey.asText();
+        }
+        JsonNode legacyKey = extraRoot.get(LEGACY_TEMPLATE_ID_KEY);
+        if (legacyKey != null && legacyKey.isTextual()) {
+            return legacyKey.asText();
+        }
+        return null;
+    }
+
+    public static String resolveTemplateId(Map<String, Object> extraFields) {
+        if (extraFields == null) {
+            return null;
+        }
+        Object shortKey = extraFields.get(TEMPLATE_ID_KEY);
+        if (shortKey instanceof String value) {
+            return value;
+        }
+        Object legacyKey = extraFields.get(LEGACY_TEMPLATE_ID_KEY);
+        if (legacyKey instanceof String value) {
+            return value;
+        }
+        return null;
+    }
+}

--- a/src/test/java/io/uverify/backend/service/CredentialVerificationTest.java
+++ b/src/test/java/io/uverify/backend/service/CredentialVerificationTest.java
@@ -189,6 +189,19 @@ class CredentialVerificationTest {
         mockServer.verify();
     }
 
+    @Test
+    void revokeCert_withShortTemplateIdKey_isProcessed() {
+        UVerifyCredentialEntity entity = credentialEntity(AUTH_HASH);
+        given(credentialRepository.findByAuthCertHash(AUTH_HASH)).willReturn(Optional.of(entity));
+        given(credentialRepository.save(any())).willReturn(entity);
+
+        identityIndexerService.processNewCertificates(List.of(
+                revokeCert("{\"uv_tid\":\"IdentityAuth\",\"t\":\"REVOKE\",\"ct\":\"identity\",\"th\":\"" + AUTH_HASH + "\"}")
+        ));
+
+        verify(credentialRepository).save(any());
+    }
+
     // ── cache eviction on revoke ───────────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/uverify/backend/service/StatisticsCategorizeTest.java
+++ b/src/test/java/io/uverify/backend/service/StatisticsCategorizeTest.java
@@ -61,4 +61,30 @@ class StatisticsCategorizeTest {
         assertEquals(UseCaseCategory.NOTARY,
                 StatisticsService.categorize("{\"uverify_template_id\":\"somethingElse\"}", mapper));
     }
+
+    @Test
+    void shortTemplateIdKeyMapsToCategories() {
+        assertEquals(UseCaseCategory.IDENTITY,
+                StatisticsService.categorize("{\"uv_tid\":\"tadamon\"}", mapper));
+        assertEquals(UseCaseCategory.CONNECTED_GOODS,
+                StatisticsService.categorize("{\"uv_tid\":\"socialHub\"}", mapper));
+        assertEquals(UseCaseCategory.STUDENT_CERTIFICATION,
+                StatisticsService.categorize("{\"uv_tid\":\"diploma\"}", mapper));
+        assertEquals(UseCaseCategory.NOTARY,
+                StatisticsService.categorize("{\"uv_tid\":\"somethingElse\"}", mapper));
+    }
+
+    @Test
+    void shortTemplateIdKeyWinsOverLegacyKey() {
+        assertEquals(UseCaseCategory.STUDENT_CERTIFICATION,
+                StatisticsService.categorize(
+                        "{\"uv_tid\":\"diploma\",\"uverify_template_id\":\"tadamon\"}", mapper));
+    }
+
+    @Test
+    void nonTextualShortKeyFallsBackToLegacyKey() {
+        assertEquals(UseCaseCategory.STUDENT_CERTIFICATION,
+                StatisticsService.categorize(
+                        "{\"uv_tid\":42,\"uverify_template_id\":\"diploma\"}", mapper));
+    }
 }


### PR DESCRIPTION
- add TemplateIdResolver with uv_tid taking precedence over uverify_template_id
- use it in statistics categorization and identity credential indexing
- cover alias mapping, precedence and uv_tid revoke certificates in tests