### PR TITLE
fix: upgrade yaci-store 0.1.6 to 2.0.2.1 for post-PV11 preprod sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <version.lombok>1.18.32</version.lombok>
         <version.spring-dotenv>4.0.0</version.spring-dotenv>
         <version.cardano-client-lib>0.7.1</version.cardano-client-lib>
-        <version.yaci-store>0.1.6</version.yaci-store>
+        <version.yaci-store>2.0.2.1</version.yaci-store>
         <version.yaci-cardano-test>0.1.0</version.yaci-cardano-test>
         <version.scalus-bloxbean-cardano-client-lib>0.10.3</version.scalus-bloxbean-cardano-client-lib>
         <version.zxing>3.5.3</version.zxing>


### PR DESCRIPTION
yaci-store 0.1.6 bundles yaci-core 0.3.8, whose CBOR parser cannot decode transactions produced after the preprod protocol-v11 hard fork. Sync stalled at block 4,966,606 with CborException: Reserved additional information and every restart re-hit the same block. 2.0.2.1 pulls yaci-core 0.4.4, which parses post-PV11 CBOR.

The internal storage impl layer the backend subclasses (UtxoStorageImpl, TransactionWitnessStorageImpl, WithdrawalStorageImpl, TxScriptStorageImpl) keeps identical constructor and overridden-method signatures in 2.x, so the four storage subclasses and all impl-layer imports compile unchanged. The TransactionEvent hook is likewise unchanged. Only the version property moves.

The store schema does not migrate in place: the 2.x utxo/transaction/ script init migrations changed content at versions already applied by 0.1.6 and V0_300_2 changed description, so Flyway validation fails on the existing DB. The store must resync on a fresh schema (see runbook).